### PR TITLE
refactor: replace calculate naming and clarify stats helpers

### DIFF
--- a/examples/ollama-single-request-example.py
+++ b/examples/ollama-single-request-example.py
@@ -3,7 +3,7 @@ import time
 
 from openai import AsyncOpenAI
 
-from llm_perf_tools import RequestMetrics, calculate_stats
+from llm_perf_tools import RequestMetrics, compute_stats
 
 
 # Prerequisites: Launch Ollama server with: ollama run gpt-oss:20b
@@ -46,7 +46,7 @@ async def main():
         output_tokens=output_tokens,
     )
 
-    stats = calculate_stats(metrics)
+    stats = compute_stats(metrics)
 
     print("\nInference Metrics:")
     print(
@@ -65,7 +65,7 @@ async def main():
     print(f"  Input tokens: {metrics.input_tokens}")
     print(f"  Output tokens: {metrics.output_tokens}")
 
-    # For single request, calculate TPS from generation time
+    # For single request, compute TPS from generation time
     if stats.ttft and stats.e2e_latency and metrics.output_tokens > 0:
         generation_time = stats.e2e_latency - stats.ttft
         tps = metrics.output_tokens / generation_time if generation_time > 0 else 0

--- a/src/llm_perf_tools/__init__.py
+++ b/src/llm_perf_tools/__init__.py
@@ -6,7 +6,7 @@ from .inference import (
     inter_token_latency,
     tokens_per_second,
     requests_per_second,
-    calculate_stats,
+    compute_stats,
     percentile,
     compute_batch_metrics,
 )
@@ -22,7 +22,7 @@ __all__ = [
     "inter_token_latency",
     "tokens_per_second",
     "requests_per_second",
-    "calculate_stats",
+    "compute_stats",
     "percentile",
     "compute_batch_metrics",
     "save_metrics_to_json",

--- a/src/llm_perf_tools/inference.py
+++ b/src/llm_perf_tools/inference.py
@@ -50,7 +50,21 @@ def requests_per_second(metrics: list[RequestMetrics], duration: float) -> float
     return completed_requests / duration
 
 
-def calculate_stats(metrics: RequestMetrics | list[RequestMetrics]) -> InferenceStats:
+def compute_stats(metrics: RequestMetrics | list[RequestMetrics]) -> InferenceStats:
+    """Compute inference statistics for a single request or a batch.
+
+    Parameters
+    ----------
+    metrics:
+        Either a single :class:`RequestMetrics` instance or a list of them.
+
+    Returns
+    -------
+    InferenceStats
+        Aggregated statistics such as time to first token and tokens per
+        second.
+    """
+
     if isinstance(metrics, RequestMetrics):
         return InferenceStats(
             ttft=time_to_first_token(metrics),
@@ -76,6 +90,21 @@ def percentile(values: list[float], percentile: float) -> float:
 def compute_batch_metrics(
     metrics_list: list[RequestMetrics], batch_duration: float
 ) -> BatchInferenceStats:
+    """Compute batch-level inference metrics.
+
+    Parameters
+    ----------
+    metrics_list:
+        Collection of :class:`RequestMetrics` from each request in the batch.
+    batch_duration:
+        Total wall-clock time for processing the batch.
+
+    Returns
+    -------
+    BatchInferenceStats
+        Aggregated statistics across all successful requests in the batch.
+    """
+
     if not metrics_list:
         return BatchInferenceStats()
 


### PR DESCRIPTION
## Summary
- rename `calculate_stats` to `compute_stats` and add helpful docstrings
- export `compute_stats` and streamline batch example to use `compute_batch_metrics`
- align examples with compute-based naming for metrics

## Testing
- `ruff check .`
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0d66799b08333a162e302189d27f5